### PR TITLE
Add version in `pyproject.toml` as dynamics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ py-modules = []
 [tool.setuptools.packages.find]
 include = ['qiskit_ibm_catalog*']
 exclude = ['qiskit_ibm_catalog*tests']
+
+[tool.setuptools.dynamic]
+version = { file = "qiskit_ibm_catalog/VERSION.txt" }


### PR DESCRIPTION
Add `pyproject.toml` version. Currently, the package is published as 0.0.0 in PyPI.