### PR TITLE
feat: use job instead of get job by id

### DIFF
--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 from typing import Optional, List
+import warnings
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_serverless.core.client import IBMServerlessClient
@@ -100,7 +101,7 @@ class QiskitFunctionsCatalog:
             **{**kwargs, **{"filter": self.PRE_FILTER_KEYWORD}}
         )
 
-    def get_job_by_id(self, job_id: str) -> Optional[Job]:
+    def job(self, job_id: str) -> Optional[Job]:
         """Returns job by id.
 
         Args:
@@ -110,6 +111,23 @@ class QiskitFunctionsCatalog:
             Job: job
         """
         return self._client.get_job_by_id(job_id=job_id)
+
+    def get_job_by_id(self, job_id: str) -> Optional[Job]:
+        """Returns job by id.
+
+        Args:
+            job_id (str): job id
+
+        Returns:
+            Job: job
+        """
+        warnings.warn(
+            "`get_job_by_id` method has been deprecated. "
+            "And will be removed in future releases. "
+            "Please, use `job` instead.",
+            DeprecationWarning,
+        )
+        return self.job(job_id=job_id)
 
     def __repr__(self) -> str:
         return "<QiskitFunctionsCatalog>"

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 from typing import Optional, List
+import warnings
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_serverless.core.client import IBMServerlessClient
@@ -116,7 +117,7 @@ class QiskitServerless:
             **{**kwargs, **{"filter": self.PRE_FILTER_KEYWORD}}
         )
 
-    def get_job_by_id(self, job_id: str) -> Optional[Job]:
+    def job(self, job_id: str) -> Optional[Job]:
         """Returns job by id.
 
         Args:
@@ -126,6 +127,23 @@ class QiskitServerless:
             Job: Job
         """
         return self._client.get_job_by_id(job_id=job_id)
+
+    def get_job_by_id(self, job_id: str) -> Optional[Job]:
+        """Returns job by id.
+
+        Args:
+            job_id (str): job id
+
+        Returns:
+            Job: Job
+        """
+        warnings.warn(
+            "`get_job_by_id` method has been deprecated. "
+            "And will be removed in future releases. "
+            "Please, use `job` instead.",
+            DeprecationWarning,
+        )
+        return self.job(job_id=job_id)
 
     def __repr__(self) -> str:
         return "<QiskitServerless>"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR deprecates the method `get_job_by_id` in favor of `job`