### PR TITLE
Tox configuration improvements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py39, py310, lint, coverage
+envlist = py311, lint, coverage, docs
 # CI: skip-next-line
 skip_missing_interpreters = true
 
@@ -19,7 +19,6 @@ commands =
   ; treon docs --threads 2
 
 [testenv:lint]
-envdir = .tox/lint
 extras = dev
 commands =
   black --check .
@@ -28,7 +27,6 @@ commands =
   mypy .
 
 [testenv:black]
-envdir = .tox/lint
 skip_install = true
 commands = black .
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This improves the tox configuration

### Details and comments

- set `py311` as only python version in envlist -- this is the version of python supported by qiskit-serverless
- Remove overlapping `envdir` from `lint` and `black` environments.  As of tox 4.0, this will cause the environments to be re-created every time a developer switches between them.