### PR TITLE
Use save_account from `IBMServerlessClient`

### DIFF
--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -23,12 +23,10 @@ from __future__ import annotations
 from typing import Optional, List
 import warnings
 
-from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_serverless import IBMServerlessClient
 from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.enums import Channel
 from qiskit_serverless.core.function import RunnableQiskitFunction
-from qiskit_serverless.exception import QiskitServerlessException
 
 
 class QiskitFunctionsCatalog:
@@ -229,7 +227,7 @@ class QiskitFunctionsCatalog:
             overwrite: ``True`` if the existing account is to be overwritten
         """
         IBMServerlessClient.save_account(
-            channel=channel_enum.value,
+            channel=channel,
             token=token,
             instance=instance,
             name=name,

--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -228,16 +228,7 @@ class QiskitFunctionsCatalog:
             name: Name of the account to save
             overwrite: ``True`` if the existing account is to be overwritten
         """
-        try:
-            channel_enum = Channel(channel)
-        except ValueError as error:
-            raise QiskitServerlessException(
-                "Your channel value is not correct. Use one of the available channels: "
-                f"{Channel.LOCAL.value}, {Channel.IBM_QUANTUM.value}, "
-                f"{Channel.IBM_CLOUD.value}, {Channel.IBM_QUANTUM_PLATFORM.value}"
-            ) from error
-
-        QiskitRuntimeService.save_account(
+        IBMServerlessClient.save_account(
             channel=channel_enum.value,
             token=token,
             instance=instance,

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -24,12 +24,10 @@ from __future__ import annotations
 from typing import Optional, List
 import warnings
 
-from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_serverless import IBMServerlessClient
 from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.enums import Channel
 from qiskit_serverless.core.function import RunnableQiskitFunction
-from qiskit_serverless.exception import QiskitServerlessException
 
 
 class QiskitServerless:
@@ -242,7 +240,7 @@ class QiskitServerless:
         """
 
         IBMServerlessClient.save_account(
-            channel=channel_enum.value,
+            channel=channel,
             token=token,
             instance=instance,
             name=name,

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -241,16 +241,7 @@ class QiskitServerless:
             overwrite: ``True`` if the existing account is to be overwritten
         """
 
-        try:
-            channel_enum = Channel(channel)
-        except ValueError as error:
-            raise QiskitServerlessException(
-                "Your channel value is not correct. Use one of the available channels: "
-                f"{Channel.LOCAL.value}, {Channel.IBM_QUANTUM.value}, "
-                f"{Channel.IBM_CLOUD.value}, {Channel.IBM_QUANTUM_PLATFORM.value}"
-            ) from error
-
-        QiskitRuntimeService.save_account(
+        IBMServerlessClient.save_account(
             channel=channel_enum.value,
             token=token,
             instance=instance,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Use the `save_account` method from `IBMServerlessClient` for consistency in the authentication process and error raising (mostly so that a serverless exception is raised instead of a qiskit-ibm-runtime exception if something goes wrong).


### Details and comments

