### PR TITLE
Change default channel from `ibm_quantum` to `ibm_quantum_platform` to support runtime 0.41+

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install qiskit-ibm-catalog
 ```python
 from qiskit_ibm_catalog import QiskitFunctionsCatalog
 
-catalog = QiskitFunctionsCatalog(token=...)
+catalog = QiskitFunctionsCatalog(token=..., instance=...)
 
 catalog.list()
 # [<QiskitFunction("ibm/...")>, ...]

--- a/docs/tutorials/catalog.ipynb
+++ b/docs/tutorials/catalog.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -33,7 +33,9 @@
     "import os\n",
     "from qiskit_ibm_catalog import QiskitFunctionsCatalog\n",
     "\n",
-    "catalog = QiskitFunctionsCatalog(token=os.environ.get(\"TOKEN\"))\n",
+    "catalog = QiskitFunctionsCatalog(\n",
+    "    token=os.environ.get(\"TOKEN\"), instance=os.environ.get(\"INSTANCE\")\n",
+    ")\n",
     "catalog"
    ]
   },

--- a/docs/tutorials/catalog.ipynb
+++ b/docs/tutorials/catalog.ipynb
@@ -27,6 +27,7 @@
    ],
    "source": [
     "\"\"\"Qiskit function catalog\"\"\"\n",
+    "\n",
     "# pylint: disable=pointless-statement\n",
     "\n",
     "import os\n",

--- a/docs/tutorials/serverless.ipynb
+++ b/docs/tutorials/serverless.ipynb
@@ -34,7 +34,9 @@
     "import os\n",
     "from qiskit_ibm_catalog import QiskitServerless, QiskitFunction\n",
     "\n",
-    "serverless = QiskitServerless(token=os.environ.get(\"TOKEN\"), instance=os.environ.get(\"INSTANCE\"))\n",
+    "serverless = QiskitServerless(\n",
+    "    token=os.environ.get(\"TOKEN\"), instance=os.environ.get(\"INSTANCE\")\n",
+    ")\n",
     "serverless"
    ]
   },

--- a/docs/tutorials/serverless.ipynb
+++ b/docs/tutorials/serverless.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -28,12 +28,13 @@
    ],
    "source": [
     "\"\"\"QiskitServerless client\"\"\"\n",
+    "\n",
     "# pylint: disable=pointless-statement\n",
     "\n",
     "import os\n",
     "from qiskit_ibm_catalog import QiskitServerless, QiskitFunction\n",
     "\n",
-    "serverless = QiskitServerless(token=os.environ.get(\"TOKEN\"))\n",
+    "serverless = QiskitServerless(token=os.environ.get(\"TOKEN\"), instance=os.environ.get(\"INSTANCE\"))\n",
     "serverless"
    ]
   },

--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -48,7 +48,7 @@ class QiskitFunctionsCatalog:
     provider with the API token::
 
         from qiskit_ibm_catalog import QiskitFunctionsCatalog
-        catalog = QiskitFunctionsCatalog(token=<INSERT_IBM_QUANTUM_TOKEN>)
+        catalog = QiskitFunctionsCatalog(token=<INSERT_IBM_QUANTUM_TOKEN>, instance=<INSERT_CRN>)
     """
 
     PRE_FILTER_KEYWORD: str = "catalog"

--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -56,7 +56,7 @@ class QiskitFunctionsCatalog:
     def __init__(
         self,
         token: Optional[str] = None,
-        channel: str = Channel.IBM_QUANTUM.value,
+        channel: str = Channel.IBM_QUANTUM_PLATFORM.value,
         instance: Optional[str] = None,
         name: Optional[str] = None,
     ) -> None:
@@ -211,7 +211,7 @@ class QiskitFunctionsCatalog:
     @staticmethod
     def save_account(
         token: Optional[str] = None,
-        channel: str = Channel.IBM_QUANTUM.value,
+        channel: str = Channel.IBM_QUANTUM_PLATFORM.value,
         instance: Optional[str] = None,
         name: Optional[str] = None,
         overwrite: Optional[bool] = False,

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -37,7 +37,7 @@ class QiskitServerless:
     Credentials can be saved to disk by calling the `save_account()` method::
 
         from qiskit_ibm_catalog import QiskitServerless
-        QiskitServerless.save_account(token=<INSERT_IBM_QUANTUM_TOKEN>)
+        QiskitServerless.save_account(token=<INSERT_IBM_QUANTUM_TOKEN>, instance=<INSERT_CRN>)
 
     Once the credentials are saved, you can simply instantiate the serverless with no
     constructor args, as shown below.
@@ -49,7 +49,7 @@ class QiskitServerless:
     serverless with the API token::
 
         from qiskit_ibm_catalog import QiskitServerless
-        serverless = QiskitServerless(token=<INSERT_IBM_QUANTUM_TOKEN>)
+        serverless = QiskitServerless(token=<INSERT_IBM_QUANTUM_TOKEN>, instance=<INSERT_CRN>)
     """
 
     PRE_FILTER_KEYWORD: str = "serverless"
@@ -57,7 +57,7 @@ class QiskitServerless:
     def __init__(
         self,
         token: Optional[str] = None,
-        channel: str = Channel.IBM_QUANTUM.value,
+        channel: str = Channel.IBM_QUANTUM_PLATFORM.value,
         instance: Optional[str] = None,
         name: Optional[str] = None,
     ) -> None:
@@ -223,7 +223,7 @@ class QiskitServerless:
     @staticmethod
     def save_account(
         token: Optional[str] = None,
-        channel: str = Channel.IBM_QUANTUM.value,
+        channel: str = Channel.IBM_QUANTUM_PLATFORM.value,
         instance: Optional[str] = None,
         name: Optional[str] = None,
         overwrite: Optional[bool] = False,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -62,7 +62,7 @@ class TestServerless(TestCase):
     )
     def test_basic_functions(self, _token_mock, jobs_mock, functions_list_mock):
         """Tests basic function of serverless client."""
-        serverless = QiskitServerless("token", "instance")
+        serverless = QiskitServerless(token="token", instance="instance")
         jobs = serverless.jobs(limit=10)
         functions = serverless.list()
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -62,7 +62,7 @@ class TestServerless(TestCase):
     )
     def test_basic_functions(self, _token_mock, jobs_mock, functions_list_mock):
         """Tests basic function of serverless client."""
-        serverless = QiskitServerless("token")
+        serverless = QiskitServerless("token", "instance")
         jobs = serverless.jobs(limit=10)
         functions = serverless.list()
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -35,7 +35,7 @@ class TestCatalog(TestCase):
     )
     def test_basic_functions(self, _token_mock, jobs_mock, functions_list_mock):
         """Tests basic function of catalog."""
-        catalog = QiskitFunctionsCatalog("token")
+        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         jobs = catalog.jobs(limit=10)
         functions = catalog.list()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Update default channel value to align with changes in newest serverless version: https://github.com/Qiskit/qiskit-serverless/pull/1705


### Details and comments

