### PR TITLE
Update GHA's pypi release

### DIFF
--- a/.github/workflows/client-pypi-release.yaml
+++ b/.github/workflows/client-pypi-release.yaml
@@ -12,24 +12,23 @@ jobs:
   release-package:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qiskit-ibm-catalog
     steps:
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 #4.1.7
-      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f #5.1.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Install Deps
-        run: pip install -U twine==5.1.1 wheel==0.44.0
-      - name: Build Artifacts
-        run: |
-          python setup.py sdist
-          python setup.py bdist_wheel
-        shell: bash
-      - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 #4.3.5
+      - name: Install dependencies
+        run: | 
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build artifacts
+        run: python -m build
+      - name: Publish release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          path: ./dist/qiskit_ibm_catalog*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        run: twine upload dist/qiskit_ibm_catalog*
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-# See pyproject.toml for project configuration.
-# This file exists for compatibility with legacy tools:
-# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR updates the GHA to release a pypi package due to an error in the qiskit-serverless repository. This way we will remove `setup.py` and start managing the metadata in the `pyproject.toml` file.