### PR TITLE
Expose backend management methods on catalog and serverless clients

### DIFF
--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 from typing import Optional, List
 import warnings
 
+from qiskit.providers import Backend
 from qiskit_serverless import IBMServerlessClient
 from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.function import RunnableQiskitFunction
 from qiskit_serverless.core.job_event import JobEvent
 
 
-class QiskitFunctionsCatalog:
+class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
     """
     A client for connecting to the Qiskit functions catalog.
 
@@ -368,6 +369,50 @@ class QiskitFunctionsCatalog:
     def provider_file_upload(self, file: str, function: QiskitFunction):
         """Uploads a file in the specific provider's Qiskit Function folder."""
         return self._client.provider_file_upload(file, function)
+
+    def backends(self, **kwargs) -> List[Backend]:
+        """Returns the backends accessible through the active instance.
+
+        Args:
+            **kwargs: Filtering options forwarded to the client (e.g. ``name``,
+                ``min_num_qubits``, ``filters``, ``refresh_cache``).
+
+        Returns:
+            List[Backend]: Backends matching the given criteria.
+        """
+        return self._client.backends(**kwargs)
+
+    def backend(self, name: str, **kwargs) -> Backend:
+        """Returns a single backend by name.
+
+        Args:
+            name: Name of the backend to retrieve.
+            **kwargs: Additional options forwarded to the client.
+
+        Returns:
+            Backend: The requested backend.
+        """
+        return self._client.backend(name, **kwargs)
+
+    def least_busy(self, **kwargs) -> Backend:
+        """Returns the backend with the fewest pending jobs.
+
+        Args:
+            **kwargs: Filtering options forwarded to the client (e.g.
+                ``min_num_qubits``, ``filters``).
+
+        Returns:
+            Backend: The least busy backend matching the given criteria.
+        """
+        return self._client.least_busy(**kwargs)
+
+    def usage(self) -> dict:
+        """Returns runtime usage information for the active instance.
+
+        Returns:
+            dict: Usage details for the active instance.
+        """
+        return self._client.usage()
 
     def __repr__(self) -> str:
         return "<QiskitFunctionsCatalog>"

--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -77,13 +77,9 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
             instance: IBM Cloud CRN
             name: Name of the account to load
         """
-        self._client = IBMServerlessClient(
-            channel=channel, token=token, instance=instance, name=name
-        )
+        self._client = IBMServerlessClient(channel=channel, token=token, instance=instance, name=name)
 
-    def load(
-        self, title: str, provider: Optional[str] = None
-    ) -> Optional[RunnableQiskitFunction]:
+    def load(self, title: str, provider: Optional[str] = None) -> Optional[RunnableQiskitFunction]:
         """Loads Qiskit function by title
 
         Args:
@@ -288,9 +284,7 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
         )
         return self.job(job_id=job_id)
 
-    def runtime_jobs(
-        self, job_id: str, runtime_session: Optional[str] = None
-    ) -> List[str]:
+    def runtime_jobs(self, job_id: str, runtime_session: Optional[str] = None) -> List[str]:
         """Returns list of qiskit runtime job ids associated to the catalog job id
         and optionally filtered by session.
 
@@ -335,9 +329,7 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
         download_location: str = "./",
     ):
         """Download a file available to the user for the specific Qiskit Function."""
-        return self._client.file_download(
-            file, function, target_name, download_location
-        )
+        return self._client.file_download(file, function, target_name, download_location)
 
     def provider_file_download(
         self,

--- a/qiskit_ibm_catalog/catalog.py
+++ b/qiskit_ibm_catalog/catalog.py
@@ -77,9 +77,13 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
             instance: IBM Cloud CRN
             name: Name of the account to load
         """
-        self._client = IBMServerlessClient(channel=channel, token=token, instance=instance, name=name)
+        self._client = IBMServerlessClient(
+            channel=channel, token=token, instance=instance, name=name
+        )
 
-    def load(self, title: str, provider: Optional[str] = None) -> Optional[RunnableQiskitFunction]:
+    def load(
+        self, title: str, provider: Optional[str] = None
+    ) -> Optional[RunnableQiskitFunction]:
         """Loads Qiskit function by title
 
         Args:
@@ -284,7 +288,9 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
         )
         return self.job(job_id=job_id)
 
-    def runtime_jobs(self, job_id: str, runtime_session: Optional[str] = None) -> List[str]:
+    def runtime_jobs(
+        self, job_id: str, runtime_session: Optional[str] = None
+    ) -> List[str]:
         """Returns list of qiskit runtime job ids associated to the catalog job id
         and optionally filtered by session.
 
@@ -329,7 +335,9 @@ class QiskitFunctionsCatalog:  # pylint: disable=too-many-public-methods
         download_location: str = "./",
     ):
         """Download a file available to the user for the specific Qiskit Function."""
-        return self._client.file_download(file, function, target_name, download_location)
+        return self._client.file_download(
+            file, function, target_name, download_location
+        )
 
     def provider_file_download(
         self,

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -81,9 +81,7 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
             instance: IBM Cloud CRN
             name: Name of the account to load
         """
-        self._client = IBMServerlessClient(
-            channel=channel, token=token, instance=instance, name=name, host=host
-        )
+        self._client = IBMServerlessClient(channel=channel, token=token, instance=instance, name=name, host=host)
 
     def upload(self, function: QiskitFunction) -> RunnableQiskitFunction:
         """Uploads qiskit function.
@@ -96,9 +94,7 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         """
         return self._client.upload(function)
 
-    def load(
-        self, title: str, provider: Optional[str] = None
-    ) -> Optional[RunnableQiskitFunction]:
+    def load(self, title: str, provider: Optional[str] = None) -> Optional[RunnableQiskitFunction]:
         """Loads qiskit function by title.
 
         Args:
@@ -304,9 +300,7 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         )
         return self.job(job_id=job_id)
 
-    def runtime_jobs(
-        self, job_id: str, runtime_session: Optional[str] = None
-    ) -> List[str]:
+    def runtime_jobs(self, job_id: str, runtime_session: Optional[str] = None) -> List[str]:
         """Returns list of qiskit runtime job ids associated to the serverless job id
         and optionally filtered by session.
 
@@ -351,9 +345,7 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         download_location: str = "./",
     ):
         """Download a file available to the user for the specific Qiskit Function."""
-        return self._client.file_download(
-            file, function, target_name, download_location
-        )
+        return self._client.file_download(file, function, target_name, download_location)
 
     def provider_file_download(
         self,

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -25,13 +25,14 @@ from __future__ import annotations
 from typing import Optional, List
 import warnings
 
+from qiskit.providers import Backend
 from qiskit_serverless import IBMServerlessClient
 from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.function import RunnableQiskitFunction
 from qiskit_serverless.core.job_event import JobEvent
 
 
-class QiskitServerless:
+class QiskitServerless:  # pylint: disable=too-many-public-methods
     """
     A client for connecting to the Qiskit serverless.
 
@@ -384,6 +385,50 @@ class QiskitServerless:
     def provider_file_upload(self, file: str, function: QiskitFunction):
         """Uploads a file in the specific provider's Qiskit Function folder."""
         return self._client.provider_file_upload(file, function)
+
+    def backends(self, **kwargs) -> List[Backend]:
+        """Returns the backends accessible through the active instance.
+
+        Args:
+            **kwargs: Filtering options forwarded to the client (e.g. ``name``,
+                ``min_num_qubits``, ``filters``, ``refresh_cache``).
+
+        Returns:
+            List[Backend]: Backends matching the given criteria.
+        """
+        return self._client.backends(**kwargs)
+
+    def backend(self, name: str, **kwargs) -> Backend:
+        """Returns a single backend by name.
+
+        Args:
+            name: Name of the backend to retrieve.
+            **kwargs: Additional options forwarded to the client.
+
+        Returns:
+            Backend: The requested backend.
+        """
+        return self._client.backend(name, **kwargs)
+
+    def least_busy(self, **kwargs) -> Backend:
+        """Returns the backend with the fewest pending jobs.
+
+        Args:
+            **kwargs: Filtering options forwarded to the client (e.g.
+                ``min_num_qubits``, ``filters``).
+
+        Returns:
+            Backend: The least busy backend matching the given criteria.
+        """
+        return self._client.least_busy(**kwargs)
+
+    def usage(self) -> dict:
+        """Returns runtime usage information for the active instance.
+
+        Returns:
+            dict: Usage details for the active instance.
+        """
+        return self._client.usage()
 
     def __repr__(self) -> str:
         return "<QiskitServerless>"

--- a/qiskit_ibm_catalog/serverless.py
+++ b/qiskit_ibm_catalog/serverless.py
@@ -81,7 +81,9 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
             instance: IBM Cloud CRN
             name: Name of the account to load
         """
-        self._client = IBMServerlessClient(channel=channel, token=token, instance=instance, name=name, host=host)
+        self._client = IBMServerlessClient(
+            channel=channel, token=token, instance=instance, name=name, host=host
+        )
 
     def upload(self, function: QiskitFunction) -> RunnableQiskitFunction:
         """Uploads qiskit function.
@@ -94,7 +96,9 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         """
         return self._client.upload(function)
 
-    def load(self, title: str, provider: Optional[str] = None) -> Optional[RunnableQiskitFunction]:
+    def load(
+        self, title: str, provider: Optional[str] = None
+    ) -> Optional[RunnableQiskitFunction]:
         """Loads qiskit function by title.
 
         Args:
@@ -300,7 +304,9 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         )
         return self.job(job_id=job_id)
 
-    def runtime_jobs(self, job_id: str, runtime_session: Optional[str] = None) -> List[str]:
+    def runtime_jobs(
+        self, job_id: str, runtime_session: Optional[str] = None
+    ) -> List[str]:
         """Returns list of qiskit runtime job ids associated to the serverless job id
         and optionally filtered by session.
 
@@ -345,7 +351,9 @@ class QiskitServerless:  # pylint: disable=too-many-public-methods
         download_location: str = "./",
     ):
         """Download a file available to the user for the specific Qiskit Function."""
-        return self._client.file_download(file, function, target_name, download_location)
+        return self._client.file_download(
+            file, function, target_name, download_location
+        )
 
     def provider_file_download(
         self,

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -400,3 +400,59 @@ class TestCatalog(TestCase):
             name="test-name",
             overwrite=True,
         )
+
+    @mock.patch.object(IBMServerlessClient, "backends", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_backends_method(self, _verify_mock, backends_mock):
+        """Tests that backends() forwards keyword arguments correctly."""
+        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        backends_mock.return_value = ["backend1", "backend2"]
+
+        result = catalog.backends(min_num_qubits=5)
+
+        backends_mock.assert_called_once_with(min_num_qubits=5)
+        assert result == ["backend1", "backend2"]
+
+    @mock.patch.object(IBMServerlessClient, "backend", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_backend_method(self, _verify_mock, backend_mock):
+        """Tests that backend() forwards the name correctly."""
+        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        backend_mock.return_value = "backend1"
+
+        result = catalog.backend("backend1")
+
+        backend_mock.assert_called_once_with("backend1")
+        assert result == "backend1"
+
+    @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_least_busy_method(self, _verify_mock, least_busy_mock):
+        """Tests that least_busy() forwards keyword arguments correctly."""
+        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        least_busy_mock.return_value = "backend1"
+
+        result = catalog.least_busy(min_num_qubits=5)
+
+        least_busy_mock.assert_called_once_with(min_num_qubits=5)
+        assert result == "backend1"
+
+    @mock.patch.object(IBMServerlessClient, "usage", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_usage_method(self, _verify_mock, usage_mock):
+        """Tests that usage() delegates to the client."""
+        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        usage_mock.return_value = {"usage": 42}
+
+        result = catalog.usage()
+
+        usage_mock.assert_called_once_with()
+        assert result == {"usage": 42}

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -14,7 +14,9 @@
 
 # pylint: disable=duplicate-code
 
+import tempfile
 from unittest import TestCase, mock
+from unittest.mock import patch
 import pytest
 
 from qiskit_serverless import IBMServerlessClient
@@ -22,62 +24,57 @@ from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.job_event import JobEvent
 from qiskit_ibm_catalog import QiskitFunctionsCatalog
 
+_LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
+_VERIFY_CREDS = "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+_CONFIG_FILE = "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+
+_INSTANCE_LIST = [
+    {
+        "crn": "my_instance",
+        "plan": "test_plan",
+        "name": "my_instance",
+        "tags": "test_tags",
+        "pricing_type": "test_pricing_type",
+    }
+]
+
+
+def _make_catalog(mock_file_path, mock_verify, mock_list_instances):
+    """Build a QiskitFunctionsCatalog suitable for unit tests."""
+    mock_list_instances.return_value = _INSTANCE_LIST
+    mock_verify.return_value = None
+    with tempfile.NamedTemporaryFile() as tmp:
+        mock_file_path.return_value = tmp.name
+    return QiskitFunctionsCatalog(token="token", instance="my_instance", channel="ibm_quantum_platform")
+
 
 class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     """TestCatalog."""
 
-    _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
-
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_authentication(self, _verify_mock, mock_list_instances):
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    def test_authentication(self, mock_file_path, mock_verify, mock_list_instances):
         """Tests authentication of serverless client."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
         # pylint: disable=protected-access
         assert catalog._client.token == "token"
-        assert catalog._client.instance == "instance"
+        assert catalog._client.instance == "my_instance"
         # pylint: enable=protected-access
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(
         IBMServerlessClient,
         "functions",
         return_value=[QiskitFunction("the-ultimate-answer")],
     )
-    @mock.patch.object(
-        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
-    )
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_basic_functions(
-        self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances
-    ):
+    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
+    def test_basic_functions(self, jobs_mock, functions_list_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests basic function of catalog."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
         jobs = catalog.jobs(limit=10)
         functions = catalog.list()
@@ -91,28 +88,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         assert len(jobs) == 1
         assert len(functions) == 1
 
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch.object(
-        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
-    )
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_jobs_with_function_filter(
-        self, _verify_mock, jobs_mock, mock_list_instances
-    ):
-        """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
+    def test_jobs_with_function_filter(self, jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+        """Tests that 'function' is forwarded and 'catalog' filter is enforced."""
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
         my_function = QiskitFunction("my-func")
 
@@ -135,52 +117,28 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         assert isinstance(jobs[0], Job)
         assert jobs[0].job_id == "42"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "function")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_load_method(self, _verify_mock, function_mock, mock_list_instances):
+    def test_load_method(self, function_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that load() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_function = mock.MagicMock()
         function_mock.return_value = mock_function
 
         result = catalog.load(title="test-function", provider="test-provider")
 
-        function_mock.assert_called_once_with(
-            title="test-function", provider="test-provider"
-        )
+        function_mock.assert_called_once_with(title="test-function", provider="test-provider")
         assert result == mock_function
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_job_method(self, _verify_mock, job_mock, mock_list_instances):
+    def test_job_method(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that job() forwards job_id correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
 
@@ -189,26 +147,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_get_job_by_id_deprecation_warning(
-        self, _verify_mock, job_mock, mock_list_instances
-    ):
+    def test_get_job_by_id_deprecation_warning(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that get_job_by_id() shows deprecation warning."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
 
@@ -225,56 +170,28 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_runtime_jobs_method(
-        self, _verify_mock, runtime_jobs_mock, mock_list_instances
-    ):
+    def test_runtime_jobs_method(self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that runtime_jobs() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job_ids = ["job1", "job2", "job3"]
         runtime_jobs_mock.return_value = mock_job_ids
 
-        result = catalog.runtime_jobs(
-            job_id="test-job-id", runtime_session="test-session"
-        )
+        result = catalog.runtime_jobs(job_id="test-job-id", runtime_session="test-session")
 
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_runtime_sessions_method(
-        self, _verify_mock, runtime_sessions_mock, mock_list_instances
-    ):
+    def test_runtime_sessions_method(self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that runtime_sessions() forwards job_id correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_session_ids = ["session1", "session2"]
         runtime_sessions_mock.return_value = mock_session_ids
 
@@ -283,24 +200,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         runtime_sessions_mock.assert_called_once_with("test-job-id")
         assert result == mock_session_ids
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "events")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_events_method(self, _verify_mock, events_mock, mock_list_instances):
+    def test_events_method(self, events_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that events() forwards job_id and kwargs correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_events = [
             JobEvent(
                 event_type="STATUS_CHANGE",
@@ -317,26 +223,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         events_mock.assert_called_once_with("test-job-id", event_type="STATUS_CHANGE")
         assert result == mock_events
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_provider_jobs_method(
-        self, _verify_mock, provider_jobs_mock, mock_list_instances
-    ):
+    def test_provider_jobs_method(self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that provider_jobs() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_jobs = [Job("job1", mock.MagicMock()), Job("job2", mock.MagicMock())]
         provider_jobs_mock.return_value = mock_jobs
         test_function = QiskitFunction("test-function")
@@ -346,24 +239,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         provider_jobs_mock.assert_called_once_with(test_function, limit=5, offset=10)
         assert result == mock_jobs
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "files")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_files_method(self, _verify_mock, files_mock, mock_list_instances):
+    def test_files_method(self, files_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that files() forwards function parameter correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["file1.txt", "file2.py", "file3.json"]
         files_mock.return_value = mock_files
         test_function = QiskitFunction("test-function")
@@ -373,26 +255,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_files")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_provider_files_method(
-        self, _verify_mock, provider_files_mock, mock_list_instances
-    ):
+    def test_provider_files_method(self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that provider_files() forwards function parameter correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["provider_file1.txt", "provider_file2.py"]
         provider_files_mock.return_value = mock_files
         test_function = QiskitFunction("test-function")
@@ -402,26 +271,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         provider_files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_download")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_download_method(
-        self, _verify_mock, file_download_mock, mock_list_instances
-    ):
+    def test_file_download_method(self, file_download_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_download() forwards all parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -432,31 +288,18 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
             download_location="/tmp/",
         )
 
-        file_download_mock.assert_called_once_with(
-            "test.txt", test_function, "downloaded.txt", "/tmp/"
-        )
+        file_download_mock.assert_called_once_with("test.txt", test_function, "downloaded.txt", "/tmp/")
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_download_method(
-        self, _verify_mock, provider_file_download_mock, mock_list_instances
+        self, provider_file_download_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         provider_file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -475,26 +318,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         )
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_upload")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_upload_method(
-        self, _verify_mock, file_upload_mock, mock_list_instances
-    ):
+    def test_file_upload_method(self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_upload() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -503,58 +333,30 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         file_upload_mock.assert_called_once_with("upload.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_upload_method(
-        self, _verify_mock, provider_file_upload_mock, mock_list_instances
+        self, provider_file_upload_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_upload() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         provider_file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = catalog.provider_file_upload(
-            file="provider_upload.txt", function=test_function
-        )
+        result = catalog.provider_file_upload(file="provider_upload.txt", function=test_function)
 
-        provider_file_upload_mock.assert_called_once_with(
-            "provider_upload.txt", test_function
-        )
+        provider_file_upload_mock.assert_called_once_with("provider_upload.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_delete")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_delete_method(
-        self, _verify_mock, file_delete_mock, mock_list_instances
-    ):
+    def test_file_delete_method(self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_delete() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -563,55 +365,29 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         file_delete_mock.assert_called_once_with("delete.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_delete_method(
-        self, _verify_mock, provider_file_delete_mock, mock_list_instances
+        self, provider_file_delete_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_delete() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         provider_file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = catalog.provider_file_delete(
-            file="provider_delete.txt", function=test_function
-        )
+        result = catalog.provider_file_delete(file="provider_delete.txt", function=test_function)
 
-        provider_file_delete_mock.assert_called_once_with(
-            "provider_delete.txt", test_function
-        )
+        provider_file_delete_mock.assert_called_once_with("provider_delete.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_repr_method(self, _verify_mock, mock_list_instances):
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    def test_repr_method(self, mock_file_path, mock_verify, mock_list_instances):
         """Tests that __repr__() returns correct string representation."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
         result = repr(catalog)
 
@@ -638,26 +414,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
             overwrite=True,
         )
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_backends_method(self, _verify_mock, backends_mock, mock_list_instances):
+    def test_backends_method(self, backends_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that backends() forwards keyword arguments correctly."""
-
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         backends_mock.return_value = ["backend1", "backend2"]
 
         result = catalog.backends(min_num_qubits=127)
@@ -665,24 +428,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         backends_mock.assert_called_once_with(min_num_qubits=127)
         assert result == ["backend1", "backend2"]
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_backend_method(self, _verify_mock, backend_mock, mock_list_instances):
+    def test_backend_method(self, backend_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that backend() forwards the name correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         backend_mock.return_value = "backend1"
 
         result = catalog.backend("backend1")
@@ -690,26 +442,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         backend_mock.assert_called_once_with("backend1")
         assert result == "backend1"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_least_busy_method(
-        self, _verify_mock, least_busy_mock, mock_list_instances
-    ):
+    def test_least_busy_method(self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that least_busy() forwards keyword arguments correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         least_busy_mock.return_value = "backend1"
 
         result = catalog.least_busy(min_num_qubits=127)
@@ -717,24 +456,13 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         least_busy_mock.assert_called_once_with(min_num_qubits=127)
         assert result == "backend1"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_usage_method(self, _verify_mock, usage_mock, mock_list_instances):
+    def test_usage_method(self, usage_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that usage() delegates to the client."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        catalog = QiskitFunctionsCatalog(token="token", instance="instance")
+        catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         usage_mock.return_value = {"usage": 42}
 
         result = catalog.usage()

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -12,6 +12,8 @@
 
 """Tests for QiskitFunctionsCatalog class."""
 
+# pylint: disable=duplicate-code
+
 from unittest import TestCase, mock
 import pytest
 
@@ -21,7 +23,7 @@ from qiskit_serverless.core.job_event import JobEvent
 from qiskit_ibm_catalog import QiskitFunctionsCatalog
 
 
-class TestCatalog(TestCase):
+class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     """TestCatalog."""
 
     _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
@@ -61,7 +63,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances):
+    def test_basic_functions(
+        self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances
+    ):
         """Tests basic function of catalog."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -94,7 +98,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock, mock_list_instances):
+    def test_jobs_with_function_filter(
+        self, _verify_mock, jobs_mock, mock_list_instances
+    ):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -188,7 +194,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock, mock_list_instances):
+    def test_get_job_by_id_deprecation_warning(
+        self, _verify_mock, job_mock, mock_list_instances
+    ):
         """Tests that get_job_by_id() shows deprecation warning."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -222,7 +230,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock, mock_list_instances):
+    def test_runtime_jobs_method(
+        self, _verify_mock, runtime_jobs_mock, mock_list_instances
+    ):
         """Tests that runtime_jobs() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -250,7 +260,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock, mock_list_instances):
+    def test_runtime_sessions_method(
+        self, _verify_mock, runtime_sessions_mock, mock_list_instances
+    ):
         """Tests that runtime_sessions() forwards job_id correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -310,7 +322,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock, mock_list_instances):
+    def test_provider_jobs_method(
+        self, _verify_mock, provider_jobs_mock, mock_list_instances
+    ):
         """Tests that provider_jobs() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -364,7 +378,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_files_method(self, _verify_mock, provider_files_mock, mock_list_instances):
+    def test_provider_files_method(
+        self, _verify_mock, provider_files_mock, mock_list_instances
+    ):
         """Tests that provider_files() forwards function parameter correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -391,7 +407,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_download_method(self, _verify_mock, file_download_mock, mock_list_instances):
+    def test_file_download_method(
+        self, _verify_mock, file_download_mock, mock_list_instances
+    ):
         """Tests that file_download() forwards all parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -462,7 +480,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_upload_method(self, _verify_mock, file_upload_mock, mock_list_instances):
+    def test_file_upload_method(
+        self, _verify_mock, file_upload_mock, mock_list_instances
+    ):
         """Tests that file_upload() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -488,7 +508,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock, mock_list_instances):
+    def test_provider_file_upload_method(
+        self, _verify_mock, provider_file_upload_mock, mock_list_instances
+    ):
         """Tests that provider_file_upload() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -518,7 +540,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_delete_method(self, _verify_mock, file_delete_mock, mock_list_instances):
+    def test_file_delete_method(
+        self, _verify_mock, file_delete_mock, mock_list_instances
+    ):
         """Tests that file_delete() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -544,7 +568,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock, mock_list_instances):
+    def test_provider_file_delete_method(
+        self, _verify_mock, provider_file_delete_mock, mock_list_instances
+    ):
         """Tests that provider_file_delete() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -669,7 +695,9 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_least_busy_method(self, _verify_mock, least_busy_mock, mock_list_instances):
+    def test_least_busy_method(
+        self, _verify_mock, least_busy_mock, mock_list_instances
+    ):
         """Tests that least_busy() forwards keyword arguments correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -24,11 +24,24 @@ from qiskit_ibm_catalog import QiskitFunctionsCatalog
 class TestCatalog(TestCase):
     """TestCatalog."""
 
+    _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
+
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_authentication(self, _verify_mock):
+    def test_authentication(self, _verify_mock, mock_list_instances):
         """Tests authentication of serverless client."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
 
         # pylint: disable=protected-access
@@ -36,6 +49,7 @@ class TestCatalog(TestCase):
         assert catalog._client.instance == "instance"
         # pylint: enable=protected-access
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(
         IBMServerlessClient,
         "functions",
@@ -47,8 +61,18 @@ class TestCatalog(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock):
+    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances):
         """Tests basic function of catalog."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
 
         jobs = catalog.jobs(limit=10)
@@ -63,14 +87,25 @@ class TestCatalog(TestCase):
         assert len(jobs) == 1
         assert len(functions) == 1
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(
         IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
     )
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock):
+    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock, mock_list_instances):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
 
         my_function = QiskitFunction("my-func")
@@ -94,12 +129,23 @@ class TestCatalog(TestCase):
         assert isinstance(jobs[0], Job)
         assert jobs[0].job_id == "42"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "function")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_load_method(self, _verify_mock, function_mock):
+    def test_load_method(self, _verify_mock, function_mock, mock_list_instances):
         """Tests that load() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_function = mock.MagicMock()
         function_mock.return_value = mock_function
@@ -111,12 +157,23 @@ class TestCatalog(TestCase):
         )
         assert result == mock_function
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "job")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_job_method(self, _verify_mock, job_mock):
+    def test_job_method(self, _verify_mock, job_mock, mock_list_instances):
         """Tests that job() forwards job_id correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
@@ -126,12 +183,23 @@ class TestCatalog(TestCase):
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "job")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock):
+    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock, mock_list_instances):
         """Tests that get_job_by_id() shows deprecation warning."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
@@ -149,12 +217,23 @@ class TestCatalog(TestCase):
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock):
+    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock, mock_list_instances):
         """Tests that runtime_jobs() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_job_ids = ["job1", "job2", "job3"]
         runtime_jobs_mock.return_value = mock_job_ids
@@ -166,12 +245,23 @@ class TestCatalog(TestCase):
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock):
+    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock, mock_list_instances):
         """Tests that runtime_sessions() forwards job_id correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_session_ids = ["session1", "session2"]
         runtime_sessions_mock.return_value = mock_session_ids
@@ -181,12 +271,23 @@ class TestCatalog(TestCase):
         runtime_sessions_mock.assert_called_once_with("test-job-id")
         assert result == mock_session_ids
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "events")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_events_method(self, _verify_mock, events_mock):
+    def test_events_method(self, _verify_mock, events_mock, mock_list_instances):
         """Tests that events() forwards job_id and kwargs correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_events = [
             JobEvent(
@@ -204,12 +305,23 @@ class TestCatalog(TestCase):
         events_mock.assert_called_once_with("test-job-id", event_type="STATUS_CHANGE")
         assert result == mock_events
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock):
+    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock, mock_list_instances):
         """Tests that provider_jobs() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_jobs = [Job("job1", mock.MagicMock()), Job("job2", mock.MagicMock())]
         provider_jobs_mock.return_value = mock_jobs
@@ -220,12 +332,23 @@ class TestCatalog(TestCase):
         provider_jobs_mock.assert_called_once_with(test_function, limit=5, offset=10)
         assert result == mock_jobs
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "files")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_files_method(self, _verify_mock, files_mock):
+    def test_files_method(self, _verify_mock, files_mock, mock_list_instances):
         """Tests that files() forwards function parameter correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_files = ["file1.txt", "file2.py", "file3.json"]
         files_mock.return_value = mock_files
@@ -236,12 +359,23 @@ class TestCatalog(TestCase):
         files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_files")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_files_method(self, _verify_mock, provider_files_mock):
+    def test_provider_files_method(self, _verify_mock, provider_files_mock, mock_list_instances):
         """Tests that provider_files() forwards function parameter correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         mock_files = ["provider_file1.txt", "provider_file2.py"]
         provider_files_mock.return_value = mock_files
@@ -252,12 +386,23 @@ class TestCatalog(TestCase):
         provider_files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_download")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_download_method(self, _verify_mock, file_download_mock):
+    def test_file_download_method(self, _verify_mock, file_download_mock, mock_list_instances):
         """Tests that file_download() forwards all parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -274,14 +419,25 @@ class TestCatalog(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
     def test_provider_file_download_method(
-        self, _verify_mock, provider_file_download_mock
+        self, _verify_mock, provider_file_download_mock, mock_list_instances
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         provider_file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -301,12 +457,23 @@ class TestCatalog(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_upload")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_upload_method(self, _verify_mock, file_upload_mock):
+    def test_file_upload_method(self, _verify_mock, file_upload_mock, mock_list_instances):
         """Tests that file_upload() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -316,12 +483,23 @@ class TestCatalog(TestCase):
         file_upload_mock.assert_called_once_with("upload.txt", test_function)
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock):
+    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock, mock_list_instances):
         """Tests that provider_file_upload() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         provider_file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -335,12 +513,23 @@ class TestCatalog(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_delete")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_delete_method(self, _verify_mock, file_delete_mock):
+    def test_file_delete_method(self, _verify_mock, file_delete_mock, mock_list_instances):
         """Tests that file_delete() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -350,12 +539,23 @@ class TestCatalog(TestCase):
         file_delete_mock.assert_called_once_with("delete.txt", test_function)
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock):
+    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock, mock_list_instances):
         """Tests that provider_file_delete() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         provider_file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
@@ -369,11 +569,22 @@ class TestCatalog(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_repr_method(self, _verify_mock):
+    def test_repr_method(self, _verify_mock, mock_list_instances):
         """Tests that __repr__() returns correct string representation."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
 
         result = repr(catalog)
@@ -401,12 +612,25 @@ class TestCatalog(TestCase):
             overwrite=True,
         )
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_backends_method(self, _verify_mock, backends_mock):
+    def test_backends_method(self, _verify_mock, backends_mock, mock_list_instances):
         """Tests that backends() forwards keyword arguments correctly."""
+
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
+
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         backends_mock.return_value = ["backend1", "backend2"]
 
@@ -415,12 +639,23 @@ class TestCatalog(TestCase):
         backends_mock.assert_called_once_with(min_num_qubits=127)
         assert result == ["backend1", "backend2"]
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_backend_method(self, _verify_mock, backend_mock):
+    def test_backend_method(self, _verify_mock, backend_mock, mock_list_instances):
         """Tests that backend() forwards the name correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         backend_mock.return_value = "backend1"
 
@@ -429,12 +664,23 @@ class TestCatalog(TestCase):
         backend_mock.assert_called_once_with("backend1")
         assert result == "backend1"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_least_busy_method(self, _verify_mock, least_busy_mock):
+    def test_least_busy_method(self, _verify_mock, least_busy_mock, mock_list_instances):
         """Tests that least_busy() forwards keyword arguments correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         least_busy_mock.return_value = "backend1"
 
@@ -443,12 +689,23 @@ class TestCatalog(TestCase):
         least_busy_mock.assert_called_once_with(min_num_qubits=127)
         assert result == "backend1"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_usage_method(self, _verify_mock, usage_mock):
+    def test_usage_method(self, _verify_mock, usage_mock, mock_list_instances):
         """Tests that usage() delegates to the client."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         usage_mock.return_value = {"usage": 42}
 

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -26,7 +26,9 @@ from qiskit_ibm_catalog import QiskitFunctionsCatalog
 
 _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
 _VERIFY_CREDS = "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-_CONFIG_FILE = "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+_CONFIG_FILE = (
+    "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+)
 
 _INSTANCE_LIST = [
     {
@@ -45,7 +47,9 @@ def _make_catalog(mock_file_path, mock_verify, mock_list_instances):
     mock_verify.return_value = None
     with tempfile.NamedTemporaryFile() as tmp:
         mock_file_path.return_value = tmp.name
-    return QiskitFunctionsCatalog(token="token", instance="my_instance", channel="ibm_quantum_platform")
+    return QiskitFunctionsCatalog(
+        token="token", instance="my_instance", channel="ibm_quantum_platform"
+    )
 
 
 class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
@@ -71,8 +75,17 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
         "functions",
         return_value=[QiskitFunction("the-ultimate-answer")],
     )
-    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
-    def test_basic_functions(self, jobs_mock, functions_list_mock, mock_file_path, mock_verify, mock_list_instances):
+    @mock.patch.object(
+        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
+    )
+    def test_basic_functions(
+        self,
+        jobs_mock,
+        functions_list_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
+    ):
         """Tests basic function of catalog."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
@@ -91,8 +104,12 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
-    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
-    def test_jobs_with_function_filter(self, jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    @mock.patch.object(
+        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
+    )
+    def test_jobs_with_function_filter(
+        self, jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that 'function' is forwarded and 'catalog' filter is enforced."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
 
@@ -121,7 +138,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "function")
-    def test_load_method(self, function_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_load_method(
+        self, function_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that load() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_function = mock.MagicMock()
@@ -129,14 +148,18 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
 
         result = catalog.load(title="test-function", provider="test-provider")
 
-        function_mock.assert_called_once_with(title="test-function", provider="test-provider")
+        function_mock.assert_called_once_with(
+            title="test-function", provider="test-provider"
+        )
         assert result == mock_function
 
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    def test_job_method(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_job_method(
+        self, job_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that job() forwards job_id correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
@@ -151,7 +174,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    def test_get_job_by_id_deprecation_warning(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_get_job_by_id_deprecation_warning(
+        self, job_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that get_job_by_id() shows deprecation warning."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
@@ -174,13 +199,17 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
-    def test_runtime_jobs_method(self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_runtime_jobs_method(
+        self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that runtime_jobs() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_job_ids = ["job1", "job2", "job3"]
         runtime_jobs_mock.return_value = mock_job_ids
 
-        result = catalog.runtime_jobs(job_id="test-job-id", runtime_session="test-session")
+        result = catalog.runtime_jobs(
+            job_id="test-job-id", runtime_session="test-session"
+        )
 
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
@@ -189,7 +218,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
-    def test_runtime_sessions_method(self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_runtime_sessions_method(
+        self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that runtime_sessions() forwards job_id correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_session_ids = ["session1", "session2"]
@@ -204,7 +235,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "events")
-    def test_events_method(self, events_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_events_method(
+        self, events_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that events() forwards job_id and kwargs correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_events = [
@@ -227,7 +260,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
-    def test_provider_jobs_method(self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_provider_jobs_method(
+        self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that provider_jobs() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_jobs = [Job("job1", mock.MagicMock()), Job("job2", mock.MagicMock())]
@@ -243,7 +278,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "files")
-    def test_files_method(self, files_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_files_method(
+        self, files_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that files() forwards function parameter correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["file1.txt", "file2.py", "file3.json"]
@@ -259,7 +296,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_files")
-    def test_provider_files_method(self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_provider_files_method(
+        self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that provider_files() forwards function parameter correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["provider_file1.txt", "provider_file2.py"]
@@ -275,7 +314,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_download")
-    def test_file_download_method(self, file_download_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_download_method(
+        self, file_download_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_download() forwards all parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_download_mock.return_value = None
@@ -288,7 +329,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
             download_location="/tmp/",
         )
 
-        file_download_mock.assert_called_once_with("test.txt", test_function, "downloaded.txt", "/tmp/")
+        file_download_mock.assert_called_once_with(
+            "test.txt", test_function, "downloaded.txt", "/tmp/"
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
@@ -296,7 +339,11 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
     def test_provider_file_download_method(
-        self, provider_file_download_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_download_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
@@ -322,7 +369,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_upload")
-    def test_file_upload_method(self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_upload_method(
+        self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_upload() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_upload_mock.return_value = None
@@ -338,23 +387,33 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
     def test_provider_file_upload_method(
-        self, provider_file_upload_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_upload_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_upload() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         provider_file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = catalog.provider_file_upload(file="provider_upload.txt", function=test_function)
+        result = catalog.provider_file_upload(
+            file="provider_upload.txt", function=test_function
+        )
 
-        provider_file_upload_mock.assert_called_once_with("provider_upload.txt", test_function)
+        provider_file_upload_mock.assert_called_once_with(
+            "provider_upload.txt", test_function
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_delete")
-    def test_file_delete_method(self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_delete_method(
+        self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_delete() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         file_delete_mock.return_value = None
@@ -370,16 +429,24 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
     def test_provider_file_delete_method(
-        self, provider_file_delete_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_delete_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_delete() forwards parameters correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         provider_file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = catalog.provider_file_delete(file="provider_delete.txt", function=test_function)
+        result = catalog.provider_file_delete(
+            file="provider_delete.txt", function=test_function
+        )
 
-        provider_file_delete_mock.assert_called_once_with("provider_delete.txt", test_function)
+        provider_file_delete_mock.assert_called_once_with(
+            "provider_delete.txt", test_function
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
@@ -418,7 +485,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
-    def test_backends_method(self, backends_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_backends_method(
+        self, backends_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that backends() forwards keyword arguments correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         backends_mock.return_value = ["backend1", "backend2"]
@@ -432,7 +501,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
-    def test_backend_method(self, backend_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_backend_method(
+        self, backend_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that backend() forwards the name correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         backend_mock.return_value = "backend1"
@@ -446,7 +517,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
-    def test_least_busy_method(self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_least_busy_method(
+        self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that least_busy() forwards keyword arguments correctly."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         least_busy_mock.return_value = "backend1"
@@ -460,7 +533,9 @@ class TestCatalog(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
-    def test_usage_method(self, usage_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_usage_method(
+        self, usage_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that usage() delegates to the client."""
         catalog = _make_catalog(mock_file_path, mock_verify, mock_list_instances)
         usage_mock.return_value = {"usage": 42}

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -410,9 +410,9 @@ class TestCatalog(TestCase):
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         backends_mock.return_value = ["backend1", "backend2"]
 
-        result = catalog.backends(min_num_qubits=5)
+        result = catalog.backends(min_num_qubits=127)
 
-        backends_mock.assert_called_once_with(min_num_qubits=5)
+        backends_mock.assert_called_once_with(min_num_qubits=127)
         assert result == ["backend1", "backend2"]
 
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
@@ -438,9 +438,9 @@ class TestCatalog(TestCase):
         catalog = QiskitFunctionsCatalog(token="token", instance="instance")
         least_busy_mock.return_value = "backend1"
 
-        result = catalog.least_busy(min_num_qubits=5)
+        result = catalog.least_busy(min_num_qubits=127)
 
-        least_busy_mock.assert_called_once_with(min_num_qubits=5)
+        least_busy_mock.assert_called_once_with(min_num_qubits=127)
         assert result == "backend1"
 
     @mock.patch.object(IBMServerlessClient, "usage", create=True)

--- a/test/test_serverless.py
+++ b/test/test_serverless.py
@@ -26,7 +26,9 @@ from qiskit_ibm_catalog import QiskitServerless
 
 _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
 _VERIFY_CREDS = "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-_CONFIG_FILE = "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+_CONFIG_FILE = (
+    "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+)
 
 _INSTANCE_LIST = [
     {
@@ -39,13 +41,17 @@ _INSTANCE_LIST = [
 ]
 
 
-def _make_serverless(mock_file_path, mock_verify, mock_list_instances, host="http://host"):
+def _make_serverless(
+    mock_file_path, mock_verify, mock_list_instances, host="http://host"
+):
     """Build a QiskitServerless suitable for unit tests."""
     mock_list_instances.return_value = _INSTANCE_LIST
     mock_verify.return_value = None
     with tempfile.NamedTemporaryFile() as tmp:
         mock_file_path.return_value = tmp.name
-    return QiskitServerless(token="token", instance="my_instance", channel="ibm_quantum_platform", host=host)
+    return QiskitServerless(
+        token="token", instance="my_instance", channel="ibm_quantum_platform", host=host
+    )
 
 
 class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
@@ -72,8 +78,17 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         "functions",
         return_value=[QiskitFunction("the-ultimate-answer")],
     )
-    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
-    def test_basic_functions(self, jobs_mock, functions_list_mock, mock_file_path, mock_verify, mock_list_instances):
+    @mock.patch.object(
+        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
+    )
+    def test_basic_functions(
+        self,
+        jobs_mock,
+        functions_list_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
+    ):
         """Tests basic function of serverless client."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
@@ -98,8 +113,12 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
-    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
-    def test_jobs_with_function_filter(self, jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    @mock.patch.object(
+        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
+    )
+    def test_jobs_with_function_filter(
+        self, jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
@@ -128,7 +147,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "upload")
-    def test_upload_method(self, upload_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_upload_method(
+        self, upload_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that upload() forwards function parameter correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         test_function = QiskitFunction("test-function")
@@ -144,7 +165,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "function")
-    def test_load_method(self, function_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_load_method(
+        self, function_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that load() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_function = mock.MagicMock()
@@ -152,14 +175,18 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
 
         result = serverless.load(title="test-function", provider="test-provider")
 
-        function_mock.assert_called_once_with(title="test-function", provider="test-provider")
+        function_mock.assert_called_once_with(
+            title="test-function", provider="test-provider"
+        )
         assert result == mock_function
 
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    def test_job_method(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_job_method(
+        self, job_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that job() forwards job_id correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
@@ -174,7 +201,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    def test_get_job_by_id_deprecation_warning(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_get_job_by_id_deprecation_warning(
+        self, job_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that get_job_by_id() shows deprecation warning."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
@@ -197,13 +226,17 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
-    def test_runtime_jobs_method(self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_runtime_jobs_method(
+        self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that runtime_jobs() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job_ids = ["job1", "job2", "job3"]
         runtime_jobs_mock.return_value = mock_job_ids
 
-        result = serverless.runtime_jobs(job_id="test-job-id", runtime_session="test-session")
+        result = serverless.runtime_jobs(
+            job_id="test-job-id", runtime_session="test-session"
+        )
 
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
@@ -212,7 +245,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
-    def test_runtime_sessions_method(self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_runtime_sessions_method(
+        self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that runtime_sessions() forwards job_id correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_session_ids = ["session1", "session2"]
@@ -227,7 +262,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "events")
-    def test_events_method(self, events_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_events_method(
+        self, events_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that events() forwards job_id and kwargs correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_events = [
@@ -250,7 +287,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
-    def test_provider_jobs_method(self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_provider_jobs_method(
+        self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that provider_jobs() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_jobs = [Job("job1", mock.MagicMock()), Job("job2", mock.MagicMock())]
@@ -266,7 +305,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "files")
-    def test_files_method(self, files_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_files_method(
+        self, files_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that files() forwards function parameter correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["file1.txt", "file2.py", "file3.json"]
@@ -282,7 +323,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_files")
-    def test_provider_files_method(self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_provider_files_method(
+        self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that provider_files() forwards function parameter correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["provider_file1.txt", "provider_file2.py"]
@@ -298,7 +341,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_download")
-    def test_file_download_method(self, file_download_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_download_method(
+        self, file_download_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_download() forwards all parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_download_mock.return_value = None
@@ -311,7 +356,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
             download_location="/tmp/",
         )
 
-        file_download_mock.assert_called_once_with("test.txt", test_function, "downloaded.txt", "/tmp/")
+        file_download_mock.assert_called_once_with(
+            "test.txt", test_function, "downloaded.txt", "/tmp/"
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
@@ -319,7 +366,11 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
     def test_provider_file_download_method(
-        self, provider_file_download_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_download_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
@@ -345,7 +396,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_upload")
-    def test_file_upload_method(self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_upload_method(
+        self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_upload() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_upload_mock.return_value = None
@@ -361,23 +414,33 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
     def test_provider_file_upload_method(
-        self, provider_file_upload_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_upload_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_upload() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         provider_file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = serverless.provider_file_upload(file="provider_upload.txt", function=test_function)
+        result = serverless.provider_file_upload(
+            file="provider_upload.txt", function=test_function
+        )
 
-        provider_file_upload_mock.assert_called_once_with("provider_upload.txt", test_function)
+        provider_file_upload_mock.assert_called_once_with(
+            "provider_upload.txt", test_function
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_delete")
-    def test_file_delete_method(self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_file_delete_method(
+        self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that file_delete() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_delete_mock.return_value = None
@@ -393,16 +456,24 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
     def test_provider_file_delete_method(
-        self, provider_file_delete_mock, mock_file_path, mock_verify, mock_list_instances
+        self,
+        provider_file_delete_mock,
+        mock_file_path,
+        mock_verify,
+        mock_list_instances,
     ):
         """Tests that provider_file_delete() forwards parameters correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         provider_file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = serverless.provider_file_delete(file="provider_delete.txt", function=test_function)
+        result = serverless.provider_file_delete(
+            file="provider_delete.txt", function=test_function
+        )
 
-        provider_file_delete_mock.assert_called_once_with("provider_delete.txt", test_function)
+        provider_file_delete_mock.assert_called_once_with(
+            "provider_delete.txt", test_function
+        )
         assert result is None
 
     @patch(_LIST_INSTANCES)
@@ -441,7 +512,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
-    def test_backends_method(self, backends_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_backends_method(
+        self, backends_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that backends() forwards keyword arguments correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         backends_mock.return_value = ["backend1", "backend2"]
@@ -455,7 +528,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
-    def test_backend_method(self, backend_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_backend_method(
+        self, backend_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that backend() forwards the name correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         backend_mock.return_value = "backend1"
@@ -469,7 +544,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
-    def test_least_busy_method(self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_least_busy_method(
+        self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that least_busy() forwards keyword arguments correctly."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         least_busy_mock.return_value = "backend1"
@@ -483,7 +560,9 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     @patch(_VERIFY_CREDS)
     @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
-    def test_usage_method(self, usage_mock, mock_file_path, mock_verify, mock_list_instances):
+    def test_usage_method(
+        self, usage_mock, mock_file_path, mock_verify, mock_list_instances
+    ):
         """Tests that usage() delegates to the client."""
         serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         usage_mock.return_value = {"usage": 42}

--- a/test/test_serverless.py
+++ b/test/test_serverless.py
@@ -14,7 +14,9 @@
 
 # pylint: disable=duplicate-code
 
+import tempfile
 from unittest import TestCase, mock
+from unittest.mock import patch
 import pytest
 
 from qiskit_serverless import IBMServerlessClient
@@ -22,71 +24,62 @@ from qiskit_serverless.core import Job, QiskitFunction
 from qiskit_serverless.core.job_event import JobEvent
 from qiskit_ibm_catalog import QiskitServerless
 
+_LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
+_VERIFY_CREDS = "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+_CONFIG_FILE = "qiskit_ibm_runtime.accounts.management._DEFAULT_ACCOUNT_CONFIG_JSON_FILE"
+
+_INSTANCE_LIST = [
+    {
+        "crn": "my_instance",
+        "plan": "test_plan",
+        "name": "my_instance",
+        "tags": "test_tags",
+        "pricing_type": "test_pricing_type",
+    }
+]
+
+
+def _make_serverless(mock_file_path, mock_verify, mock_list_instances, host="http://host"):
+    """Build a QiskitServerless suitable for unit tests."""
+    mock_list_instances.return_value = _INSTANCE_LIST
+    mock_verify.return_value = None
+    with tempfile.NamedTemporaryFile() as tmp:
+        mock_file_path.return_value = tmp.name
+    return QiskitServerless(token="token", instance="my_instance", channel="ibm_quantum_platform", host=host)
+
 
 class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     """TestServerless."""
 
-    _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
-
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_authentication(self, _verify_mock, mock_list_instances):
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    def test_authentication(self, mock_file_path, mock_verify, mock_list_instances):
         """Tests authentication of serverless client."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
         # pylint: disable=protected-access
         assert serverless._client.token == "token"
-        assert serverless._client.instance == "instance"
+        assert serverless._client.instance == "my_instance"
         assert serverless._client.host == "http://host"
         # pylint: enable=protected-access
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(
         IBMServerlessClient,
         "functions",
         return_value=[QiskitFunction("the-ultimate-answer")],
     )
-    @mock.patch.object(
-        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
-    )
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_basic_functions(
-        self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances
-    ):
+    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
+    def test_basic_functions(self, jobs_mock, functions_list_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests basic function of serverless client."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
         # pylint: disable=protected-access
         assert serverless._client.token == "token"
-        assert serverless._client.instance == "instance"
+        assert serverless._client.instance == "my_instance"
         assert serverless._client.host == "http://host"
         # pylint: enable=protected-access
 
@@ -102,30 +95,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         assert len(jobs) == 1
         assert len(functions) == 1
 
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch.object(
-        IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
-    )
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_jobs_with_function_filter(
-        self, _verify_mock, jobs_mock, mock_list_instances
-    ):
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    @mock.patch.object(IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())])
+    def test_jobs_with_function_filter(self, jobs_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
         my_function = QiskitFunction("my-func")
 
@@ -148,26 +124,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         assert isinstance(jobs[0], Job)
         assert jobs[0].job_id == "42"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "upload")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_upload_method(self, _verify_mock, upload_mock, mock_list_instances):
+    def test_upload_method(self, upload_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that upload() forwards function parameter correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         test_function = QiskitFunction("test-function")
         mock_uploaded_function = mock.MagicMock()
         upload_mock.return_value = mock_uploaded_function
@@ -177,56 +140,28 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         upload_mock.assert_called_once_with(test_function)
         assert result == mock_uploaded_function
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "function")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_load_method(self, _verify_mock, function_mock, mock_list_instances):
+    def test_load_method(self, function_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that load() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_function = mock.MagicMock()
         function_mock.return_value = mock_function
 
         result = serverless.load(title="test-function", provider="test-provider")
 
-        function_mock.assert_called_once_with(
-            title="test-function", provider="test-provider"
-        )
+        function_mock.assert_called_once_with(title="test-function", provider="test-provider")
         assert result == mock_function
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_job_method(self, _verify_mock, job_mock, mock_list_instances):
+    def test_job_method(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that job() forwards job_id correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
 
@@ -235,28 +170,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "job")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_get_job_by_id_deprecation_warning(
-        self, _verify_mock, job_mock, mock_list_instances
-    ):
+    def test_get_job_by_id_deprecation_warning(self, job_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that get_job_by_id() shows deprecation warning."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job = Job("test-job-id", mock.MagicMock())
         job_mock.return_value = mock_job
 
@@ -273,60 +193,28 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_runtime_jobs_method(
-        self, _verify_mock, runtime_jobs_mock, mock_list_instances
-    ):
+    def test_runtime_jobs_method(self, runtime_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that runtime_jobs() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_job_ids = ["job1", "job2", "job3"]
         runtime_jobs_mock.return_value = mock_job_ids
 
-        result = serverless.runtime_jobs(
-            job_id="test-job-id", runtime_session="test-session"
-        )
+        result = serverless.runtime_jobs(job_id="test-job-id", runtime_session="test-session")
 
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_runtime_sessions_method(
-        self, _verify_mock, runtime_sessions_mock, mock_list_instances
-    ):
+    def test_runtime_sessions_method(self, runtime_sessions_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that runtime_sessions() forwards job_id correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_session_ids = ["session1", "session2"]
         runtime_sessions_mock.return_value = mock_session_ids
 
@@ -335,26 +223,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         runtime_sessions_mock.assert_called_once_with("test-job-id")
         assert result == mock_session_ids
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "events")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_events_method(self, _verify_mock, events_mock, mock_list_instances):
+    def test_events_method(self, events_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that events() forwards job_id and kwargs correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_events = [
             JobEvent(
                 event_type="STATUS_CHANGE",
@@ -371,28 +246,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         events_mock.assert_called_once_with("test-job-id", event_type="STATUS_CHANGE")
         assert result == mock_events
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_provider_jobs_method(
-        self, _verify_mock, provider_jobs_mock, mock_list_instances
-    ):
+    def test_provider_jobs_method(self, provider_jobs_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that provider_jobs() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_jobs = [Job("job1", mock.MagicMock()), Job("job2", mock.MagicMock())]
         provider_jobs_mock.return_value = mock_jobs
         test_function = QiskitFunction("test-function")
@@ -402,26 +262,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         provider_jobs_mock.assert_called_once_with(test_function, limit=5, offset=10)
         assert result == mock_jobs
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "files")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_files_method(self, _verify_mock, files_mock, mock_list_instances):
+    def test_files_method(self, files_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that files() forwards function parameter correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["file1.txt", "file2.py", "file3.json"]
         files_mock.return_value = mock_files
         test_function = QiskitFunction("test-function")
@@ -431,28 +278,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_files")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_provider_files_method(
-        self, _verify_mock, provider_files_mock, mock_list_instances
-    ):
+    def test_provider_files_method(self, provider_files_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that provider_files() forwards function parameter correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         mock_files = ["provider_file1.txt", "provider_file2.py"]
         provider_files_mock.return_value = mock_files
         test_function = QiskitFunction("test-function")
@@ -462,28 +294,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         provider_files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_download")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_download_method(
-        self, _verify_mock, file_download_mock, mock_list_instances
-    ):
+    def test_file_download_method(self, file_download_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_download() forwards all parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -494,33 +311,18 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
             download_location="/tmp/",
         )
 
-        file_download_mock.assert_called_once_with(
-            "test.txt", test_function, "downloaded.txt", "/tmp/"
-        )
+        file_download_mock.assert_called_once_with("test.txt", test_function, "downloaded.txt", "/tmp/")
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_download_method(
-        self, _verify_mock, provider_file_download_mock, mock_list_instances
+        self, provider_file_download_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         provider_file_download_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -539,28 +341,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         )
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_upload")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_upload_method(
-        self, _verify_mock, file_upload_mock, mock_list_instances
-    ):
+    def test_file_upload_method(self, file_upload_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_upload() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -569,62 +356,30 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         file_upload_mock.assert_called_once_with("upload.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_upload_method(
-        self, _verify_mock, provider_file_upload_mock, mock_list_instances
+        self, provider_file_upload_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_upload() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         provider_file_upload_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = serverless.provider_file_upload(
-            file="provider_upload.txt", function=test_function
-        )
+        result = serverless.provider_file_upload(file="provider_upload.txt", function=test_function)
 
-        provider_file_upload_mock.assert_called_once_with(
-            "provider_upload.txt", test_function
-        )
+        provider_file_upload_mock.assert_called_once_with("provider_upload.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "file_delete")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_file_delete_method(
-        self, _verify_mock, file_delete_mock, mock_list_instances
-    ):
+    def test_file_delete_method(self, file_delete_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that file_delete() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
@@ -633,59 +388,29 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         file_delete_mock.assert_called_once_with("delete.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
     def test_provider_file_delete_method(
-        self, _verify_mock, provider_file_delete_mock, mock_list_instances
+        self, provider_file_delete_mock, mock_file_path, mock_verify, mock_list_instances
     ):
         """Tests that provider_file_delete() forwards parameters correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         provider_file_delete_mock.return_value = None
         test_function = QiskitFunction("test-function")
 
-        result = serverless.provider_file_delete(
-            file="provider_delete.txt", function=test_function
-        )
+        result = serverless.provider_file_delete(file="provider_delete.txt", function=test_function)
 
-        provider_file_delete_mock.assert_called_once_with(
-            "provider_delete.txt", test_function
-        )
+        provider_file_delete_mock.assert_called_once_with("provider_delete.txt", test_function)
         assert result is None
 
-    @mock.patch(_LIST_INSTANCES)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_repr_method(self, _verify_mock, mock_list_instances):
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
+    def test_repr_method(self, mock_file_path, mock_verify, mock_list_instances):
         """Tests that __repr__() returns correct string representation."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(
-            token="token", instance="instance", host="http://host"
-        )
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
 
         result = repr(serverless)
 
@@ -712,24 +437,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
             overwrite=True,
         )
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_backends_method(self, _verify_mock, backends_mock, mock_list_instances):
+    def test_backends_method(self, backends_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that backends() forwards keyword arguments correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(token="token", instance="instance")
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         backends_mock.return_value = ["backend1", "backend2"]
 
         result = serverless.backends(min_num_qubits=5)
@@ -737,24 +451,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         backends_mock.assert_called_once_with(min_num_qubits=5)
         assert result == ["backend1", "backend2"]
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_backend_method(self, _verify_mock, backend_mock, mock_list_instances):
+    def test_backend_method(self, backend_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that backend() forwards the name correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(token="token", instance="instance")
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         backend_mock.return_value = "backend1"
 
         result = serverless.backend("backend1")
@@ -762,26 +465,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         backend_mock.assert_called_once_with("backend1")
         assert result == "backend1"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_least_busy_method(
-        self, _verify_mock, least_busy_mock, mock_list_instances
-    ):
+    def test_least_busy_method(self, least_busy_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that least_busy() forwards keyword arguments correctly."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(token="token", instance="instance")
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         least_busy_mock.return_value = "backend1"
 
         result = serverless.least_busy(min_num_qubits=5)
@@ -789,24 +479,13 @@ class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
         least_busy_mock.assert_called_once_with(min_num_qubits=5)
         assert result == "backend1"
 
-    @mock.patch(_LIST_INSTANCES)
+    @patch(_LIST_INSTANCES)
+    @patch(_VERIFY_CREDS)
+    @patch(_CONFIG_FILE)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
-    @mock.patch(
-        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
-    )
-    def test_usage_method(self, _verify_mock, usage_mock, mock_list_instances):
+    def test_usage_method(self, usage_mock, mock_file_path, mock_verify, mock_list_instances):
         """Tests that usage() delegates to the client."""
-        # Mock list of instance crns in the IBM Cloud Global
-        mock_list_instances.return_value = [
-            {
-                "crn": "my_instance",
-                "plan": "test_plan",
-                "name": "my_instance",
-                "tags": "test_tags",
-                "pricing_type": "test_pricing_type",
-            }
-        ]
-        serverless = QiskitServerless(token="token", instance="instance")
+        serverless = _make_serverless(mock_file_path, mock_verify, mock_list_instances)
         usage_mock.return_value = {"usage": 42}
 
         result = serverless.usage()

--- a/test/test_serverless.py
+++ b/test/test_serverless.py
@@ -24,11 +24,24 @@ from qiskit_ibm_catalog import QiskitServerless
 class TestServerless(TestCase):
     """TestServerless."""
 
+    _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
+
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_authentication(self, _verify_mock):
+    def test_authentication(self, _verify_mock, mock_list_instances):
         """Tests authentication of serverless client."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -39,6 +52,7 @@ class TestServerless(TestCase):
         assert serverless._client.host == "http://host"
         # pylint: enable=protected-access
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(
         IBMServerlessClient,
         "functions",
@@ -50,8 +64,18 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock):
+    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances):
         """Tests basic function of serverless client."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -74,14 +98,25 @@ class TestServerless(TestCase):
         assert len(jobs) == 1
         assert len(functions) == 1
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(
         IBMServerlessClient, "jobs", return_value=[Job("42", mock.MagicMock())]
     )
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock):
+    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock, mock_list_instances):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -107,12 +142,23 @@ class TestServerless(TestCase):
         assert isinstance(jobs[0], Job)
         assert jobs[0].job_id == "42"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "upload")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_upload_method(self, _verify_mock, upload_mock):
+    def test_upload_method(self, _verify_mock, upload_mock, mock_list_instances):
         """Tests that upload() forwards function parameter correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -125,12 +171,23 @@ class TestServerless(TestCase):
         upload_mock.assert_called_once_with(test_function)
         assert result == mock_uploaded_function
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "function")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_load_method(self, _verify_mock, function_mock):
+    def test_load_method(self, _verify_mock, function_mock, mock_list_instances):
         """Tests that load() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -144,12 +201,23 @@ class TestServerless(TestCase):
         )
         assert result == mock_function
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "job")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_job_method(self, _verify_mock, job_mock):
+    def test_job_method(self, _verify_mock, job_mock, mock_list_instances):
         """Tests that job() forwards job_id correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -161,12 +229,23 @@ class TestServerless(TestCase):
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "job")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock):
+    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock, mock_list_instances):
         """Tests that get_job_by_id() shows deprecation warning."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -186,12 +265,23 @@ class TestServerless(TestCase):
         job_mock.assert_called_once_with(job_id="test-job-id")
         assert result == mock_job
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "runtime_jobs")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock):
+    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock, mock_list_instances):
         """Tests that runtime_jobs() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -205,12 +295,23 @@ class TestServerless(TestCase):
         runtime_jobs_mock.assert_called_once_with("test-job-id", "test-session")
         assert result == mock_job_ids
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "runtime_sessions")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock):
+    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock, mock_list_instances):
         """Tests that runtime_sessions() forwards job_id correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -222,12 +323,23 @@ class TestServerless(TestCase):
         runtime_sessions_mock.assert_called_once_with("test-job-id")
         assert result == mock_session_ids
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "events")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_events_method(self, _verify_mock, events_mock):
+    def test_events_method(self, _verify_mock, events_mock, mock_list_instances):
         """Tests that events() forwards job_id and kwargs correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -247,12 +359,23 @@ class TestServerless(TestCase):
         events_mock.assert_called_once_with("test-job-id", event_type="STATUS_CHANGE")
         assert result == mock_events
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_jobs")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock):
+    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock, mock_list_instances):
         """Tests that provider_jobs() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -265,12 +388,23 @@ class TestServerless(TestCase):
         provider_jobs_mock.assert_called_once_with(test_function, limit=5, offset=10)
         assert result == mock_jobs
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "files")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_files_method(self, _verify_mock, files_mock):
+    def test_files_method(self, _verify_mock, files_mock, mock_list_instances):
         """Tests that files() forwards function parameter correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -283,12 +417,23 @@ class TestServerless(TestCase):
         files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_files")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_files_method(self, _verify_mock, provider_files_mock):
+    def test_provider_files_method(self, _verify_mock, provider_files_mock, mock_list_instances):
         """Tests that provider_files() forwards function parameter correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -301,12 +446,23 @@ class TestServerless(TestCase):
         provider_files_mock.assert_called_once_with(test_function)
         assert result == mock_files
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_download")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_download_method(self, _verify_mock, file_download_mock):
+    def test_file_download_method(self, _verify_mock, file_download_mock, mock_list_instances):
         """Tests that file_download() forwards all parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -325,14 +481,25 @@ class TestServerless(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_download")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
     def test_provider_file_download_method(
-        self, _verify_mock, provider_file_download_mock
+        self, _verify_mock, provider_file_download_mock, mock_list_instances
     ):
         """Tests that provider_file_download() forwards all parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -354,12 +521,23 @@ class TestServerless(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_upload")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_upload_method(self, _verify_mock, file_upload_mock):
+    def test_file_upload_method(self, _verify_mock, file_upload_mock, mock_list_instances):
         """Tests that file_upload() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -371,12 +549,23 @@ class TestServerless(TestCase):
         file_upload_mock.assert_called_once_with("upload.txt", test_function)
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_upload")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock):
+    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock, mock_list_instances):
         """Tests that provider_file_upload() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -392,12 +581,23 @@ class TestServerless(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "file_delete")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_delete_method(self, _verify_mock, file_delete_mock):
+    def test_file_delete_method(self, _verify_mock, file_delete_mock, mock_list_instances):
         """Tests that file_delete() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -409,12 +609,23 @@ class TestServerless(TestCase):
         file_delete_mock.assert_called_once_with("delete.txt", test_function)
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "provider_file_delete")
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock):
+    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock, mock_list_instances):
         """Tests that provider_file_delete() forwards parameters correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -430,11 +641,22 @@ class TestServerless(TestCase):
         )
         assert result is None
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_repr_method(self, _verify_mock):
+    def test_repr_method(self, _verify_mock, mock_list_instances):
         """Tests that __repr__() returns correct string representation."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(
             token="token", instance="instance", host="http://host"
         )
@@ -464,12 +686,23 @@ class TestServerless(TestCase):
             overwrite=True,
         )
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "backends", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_backends_method(self, _verify_mock, backends_mock):
+    def test_backends_method(self, _verify_mock, backends_mock, mock_list_instances):
         """Tests that backends() forwards keyword arguments correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(token="token", instance="instance")
         backends_mock.return_value = ["backend1", "backend2"]
 
@@ -478,12 +711,23 @@ class TestServerless(TestCase):
         backends_mock.assert_called_once_with(min_num_qubits=5)
         assert result == ["backend1", "backend2"]
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "backend", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_backend_method(self, _verify_mock, backend_mock):
+    def test_backend_method(self, _verify_mock, backend_mock, mock_list_instances):
         """Tests that backend() forwards the name correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(token="token", instance="instance")
         backend_mock.return_value = "backend1"
 
@@ -492,12 +736,23 @@ class TestServerless(TestCase):
         backend_mock.assert_called_once_with("backend1")
         assert result == "backend1"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_least_busy_method(self, _verify_mock, least_busy_mock):
+    def test_least_busy_method(self, _verify_mock, least_busy_mock, mock_list_instances):
         """Tests that least_busy() forwards keyword arguments correctly."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(token="token", instance="instance")
         least_busy_mock.return_value = "backend1"
 
@@ -506,12 +761,23 @@ class TestServerless(TestCase):
         least_busy_mock.assert_called_once_with(min_num_qubits=5)
         assert result == "backend1"
 
+    @mock.patch(_LIST_INSTANCES)
     @mock.patch.object(IBMServerlessClient, "usage", create=True)
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_usage_method(self, _verify_mock, usage_mock):
+    def test_usage_method(self, _verify_mock, usage_mock, mock_list_instances):
         """Tests that usage() delegates to the client."""
+        # Mock list of instance crns in the IBM Cloud Global
+        mock_list_instances.return_value = [
+            {
+                "crn": "my_instance",
+                "plan": "test_plan",
+                "name": "my_instance",
+                "tags": "test_tags",
+                "pricing_type": "test_pricing_type",
+            }
+        ]
         serverless = QiskitServerless(token="token", instance="instance")
         usage_mock.return_value = {"usage": 42}
 

--- a/test/test_serverless.py
+++ b/test/test_serverless.py
@@ -463,3 +463,59 @@ class TestServerless(TestCase):
             name="test-name",
             overwrite=True,
         )
+
+    @mock.patch.object(IBMServerlessClient, "backends", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_backends_method(self, _verify_mock, backends_mock):
+        """Tests that backends() forwards keyword arguments correctly."""
+        serverless = QiskitServerless(token="token", instance="instance")
+        backends_mock.return_value = ["backend1", "backend2"]
+
+        result = serverless.backends(min_num_qubits=5)
+
+        backends_mock.assert_called_once_with(min_num_qubits=5)
+        assert result == ["backend1", "backend2"]
+
+    @mock.patch.object(IBMServerlessClient, "backend", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_backend_method(self, _verify_mock, backend_mock):
+        """Tests that backend() forwards the name correctly."""
+        serverless = QiskitServerless(token="token", instance="instance")
+        backend_mock.return_value = "backend1"
+
+        result = serverless.backend("backend1")
+
+        backend_mock.assert_called_once_with("backend1")
+        assert result == "backend1"
+
+    @mock.patch.object(IBMServerlessClient, "least_busy", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_least_busy_method(self, _verify_mock, least_busy_mock):
+        """Tests that least_busy() forwards keyword arguments correctly."""
+        serverless = QiskitServerless(token="token", instance="instance")
+        least_busy_mock.return_value = "backend1"
+
+        result = serverless.least_busy(min_num_qubits=5)
+
+        least_busy_mock.assert_called_once_with(min_num_qubits=5)
+        assert result == "backend1"
+
+    @mock.patch.object(IBMServerlessClient, "usage", create=True)
+    @mock.patch(
+        "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
+    )
+    def test_usage_method(self, _verify_mock, usage_mock):
+        """Tests that usage() delegates to the client."""
+        serverless = QiskitServerless(token="token", instance="instance")
+        usage_mock.return_value = {"usage": 42}
+
+        result = serverless.usage()
+
+        usage_mock.assert_called_once_with()
+        assert result == {"usage": 42}

--- a/test/test_serverless.py
+++ b/test/test_serverless.py
@@ -12,6 +12,8 @@
 
 """Tests for QiskitServerless class."""
 
+# pylint: disable=duplicate-code
+
 from unittest import TestCase, mock
 import pytest
 
@@ -21,7 +23,7 @@ from qiskit_serverless.core.job_event import JobEvent
 from qiskit_ibm_catalog import QiskitServerless
 
 
-class TestServerless(TestCase):
+class TestServerless(TestCase):  # pylint: disable=too-many-public-methods
     """TestServerless."""
 
     _LIST_INSTANCES = "qiskit_ibm_runtime.accounts.account.CloudAccount.list_instances"
@@ -64,7 +66,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_basic_functions(self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances):
+    def test_basic_functions(
+        self, _verify_mock, jobs_mock, functions_list_mock, mock_list_instances
+    ):
         """Tests basic function of serverless client."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -105,7 +109,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_jobs_with_function_filter(self, _verify_mock, jobs_mock, mock_list_instances):
+    def test_jobs_with_function_filter(
+        self, _verify_mock, jobs_mock, mock_list_instances
+    ):
         """Tests that 'function' is forwarded and 'serverless' filter is enforced."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -234,7 +240,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_get_job_by_id_deprecation_warning(self, _verify_mock, job_mock, mock_list_instances):
+    def test_get_job_by_id_deprecation_warning(
+        self, _verify_mock, job_mock, mock_list_instances
+    ):
         """Tests that get_job_by_id() shows deprecation warning."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -270,7 +278,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_jobs_method(self, _verify_mock, runtime_jobs_mock, mock_list_instances):
+    def test_runtime_jobs_method(
+        self, _verify_mock, runtime_jobs_mock, mock_list_instances
+    ):
         """Tests that runtime_jobs() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -300,7 +310,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_runtime_sessions_method(self, _verify_mock, runtime_sessions_mock, mock_list_instances):
+    def test_runtime_sessions_method(
+        self, _verify_mock, runtime_sessions_mock, mock_list_instances
+    ):
         """Tests that runtime_sessions() forwards job_id correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -364,7 +376,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_jobs_method(self, _verify_mock, provider_jobs_mock, mock_list_instances):
+    def test_provider_jobs_method(
+        self, _verify_mock, provider_jobs_mock, mock_list_instances
+    ):
         """Tests that provider_jobs() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -422,7 +436,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_files_method(self, _verify_mock, provider_files_mock, mock_list_instances):
+    def test_provider_files_method(
+        self, _verify_mock, provider_files_mock, mock_list_instances
+    ):
         """Tests that provider_files() forwards function parameter correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -451,7 +467,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_download_method(self, _verify_mock, file_download_mock, mock_list_instances):
+    def test_file_download_method(
+        self, _verify_mock, file_download_mock, mock_list_instances
+    ):
         """Tests that file_download() forwards all parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -526,7 +544,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_upload_method(self, _verify_mock, file_upload_mock, mock_list_instances):
+    def test_file_upload_method(
+        self, _verify_mock, file_upload_mock, mock_list_instances
+    ):
         """Tests that file_upload() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -554,7 +574,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_upload_method(self, _verify_mock, provider_file_upload_mock, mock_list_instances):
+    def test_provider_file_upload_method(
+        self, _verify_mock, provider_file_upload_mock, mock_list_instances
+    ):
         """Tests that provider_file_upload() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -586,7 +608,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_file_delete_method(self, _verify_mock, file_delete_mock, mock_list_instances):
+    def test_file_delete_method(
+        self, _verify_mock, file_delete_mock, mock_list_instances
+    ):
         """Tests that file_delete() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -614,7 +638,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_provider_file_delete_method(self, _verify_mock, provider_file_delete_mock, mock_list_instances):
+    def test_provider_file_delete_method(
+        self, _verify_mock, provider_file_delete_mock, mock_list_instances
+    ):
         """Tests that provider_file_delete() forwards parameters correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [
@@ -741,7 +767,9 @@ class TestServerless(TestCase):
     @mock.patch(
         "qiskit_serverless.core.clients.serverless_client.ServerlessClient._verify_credentials"
     )
-    def test_least_busy_method(self, _verify_mock, least_busy_mock, mock_list_instances):
+    def test_least_busy_method(
+        self, _verify_mock, least_busy_mock, mock_list_instances
+    ):
         """Tests that least_busy() forwards keyword arguments correctly."""
         # Mock list of instance crns in the IBM Cloud Global
         mock_list_instances.return_value = [

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ setenv =
   LC_ALL=en_US.utf-8
 deps =
     -r{toxinidir}/requirements-dev.txt
+allowlist_externals = pip
+commands_pre =
+  pip install --force-reinstall git+https://github.com/Qiskit/qiskit-serverless\#subdirectory=client
 commands =
   pip check
   python -m pytest -v --doctest-modules


### PR DESCRIPTION
## Summary

Exposes four new methods on both `QiskitFunctionsCatalog` and `QiskitServerless`, delegating to the underlying `IBMServerlessClient`:

- `backends(**kwargs)` — backends accessible through the active instance
- `backend(name, **kwargs)` — fetch a single backend by name
- `least_busy(**kwargs)` — backend with the fewest pending jobs
- `usage()` — runtime usage information for the active instance

Each follows the existing thin-facade style (key params + `**kwargs` passthrough), keeping the client loosely coupled to upstream signatures.

Also includes two small fixes to existing code touched by this change:
- Added `from qiskit.providers import Backend` — it was referenced in the `backends()` return type hint but never imported.
- Fixed the `QiskitServerless.backends()` signature (`self, kwargs` → `self, **kwargs`).

## Tests

Added minimal forwarding tests (4 per client, 8 total) that assert delegation to `IBMServerlessClient`. Functional behaviour is tested upstream in `qiskit-serverless`, so these only verify the client wiring.

## ⚠️ Blocked on upstream

These methods depend on the new client interface from Qiskit/qiskit-serverless#2239. That PR must be **merged and released**, and the `qiskit-serverless` requirement bumped here, before this lands — until then `pylint` reports `E1101 no-member` for the four calls (the installed `qiskit-serverless~=0.32.0` does not yet have these methods).
